### PR TITLE
Use nginx instead of lwan for fake api

### DIFF
--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       8080;
+    listen  [::]:8080;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.json index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.json;
+    location = /50x.json {
+        root   /usr/share/nginx/html;
+    }
+}
+

--- a/data/index.json
+++ b/data/index.json
@@ -1,0 +1,3 @@
+{
+  "data": "This is fake api served by nginx"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,9 +85,10 @@ services:
     ports:
       - "15672:15672"
   fake_api:
-    image: jaxgeller/lwan
+    image: nginx:1.23.4-alpine
     volumes:
-      - ./data:/lwan/wwwroot
+      - ./config/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./data:/usr/share/nginx/html
     ports:
       - "8000:8080"
   web:


### PR DESCRIPTION
Fake api (lwan container) throws following error on default configuration 


```bash
docker logs krakend-enterprise-playgound-fake_api-1
Loading configuration file: lwan.conf.
calloc: Cannot allocate memory.
```

This PR fixes it by replacing lwan with nginx


```bash
$ docker -v 
Docker version 24.0.0, build 98fdcd769b
$ docker-compose -v
Docker Compose version 2.18.1
$ uname -r
6.3.2-arch1-1
```

swap disabled