### PR TITLE
Fix SWAPI GraphQL backend URL

### DIFF
--- a/config/krakend/extended/templates/endpoints_services_connectivity.json
+++ b/config/krakend/extended/templates/endpoints_services_connectivity.json
@@ -116,7 +116,7 @@
                 "host": [
                     "https://swapi-graphql.netlify.app/"
                 ],
-                "url_pattern": "/.netlify/functions/index",
+                "url_pattern": "/graphql",
                 "target": "data.film",
                 "extra_config": {
                     "backend/graphql": {

--- a/config/krakend/krakend.json
+++ b/config/krakend/krakend.json
@@ -852,7 +852,7 @@
           "host": [
             "https://swapi-graphql.netlify.app/"
           ],
-          "url_pattern": "/.netlify/functions/index",
+          "url_pattern": "/graphql",
           "target": "data.film",
           "extra_config": {
             "backend/graphql": {


### PR DESCRIPTION
The SWAPI GraphQL backend behind /starwars_films/{movie_id} was pointing at /.netlify/functions/index, which now 301-redirects. KrakenD doesn't follow the redirect, so the endpoint was broken.

Switched the url_pattern to /graphql, which returns 200. Verified end-to-end through the gateway (/starwars_films/1 -> 200). Change applied to the Flexible Config template and the compiled krakend.json.