### PR TITLE
Restore Jaeger tracing regressed in 198cb4b (+ pin tempo/keycloak)

### DIFF
--- a/config/krakend/extended/extra_config/otel.json
+++ b/config/krakend/extended/extra_config/otel.json
@@ -1,7 +1,7 @@
 {
     "service_name": "playground_enterprise_otel",
     "metric_reporting_period": 1,
-    "trace_sample_rate": 0.5,
+    "trace_sample_rate": 1,
     "exporters": { 
         "prometheus": [
             {
@@ -40,7 +40,6 @@
                 "host": "{{ .opentelemetry.jaegergrpc.host }}",
                 "port": {{ .opentelemetry.jaegergrpc.port }},
                 "use_http": false,
-                "disable_traces": true,
                 "disable_metrics": true
             }
         ]

--- a/config/krakend/extended/settings/root.vars.json
+++ b/config/krakend/extended/settings/root.vars.json
@@ -15,7 +15,7 @@
     },
     "jaegergrpc": {
         "port": 4317,
-        "host": "jaeeger"
+        "host": "jaeger"
     },
     "datadog": {
         "disable_metrics": true,

--- a/config/krakend/krakend.json
+++ b/config/krakend/krakend.json
@@ -2161,8 +2161,7 @@
           },
           {
             "disable_metrics": true,
-            "disable_traces": true,
-            "host": "jaeeger",
+            "host": "jaeger",
             "name": "debug_jaeger",
             "port": 4317,
             "use_http": false
@@ -2220,7 +2219,7 @@
       },
       "metric_reporting_period": 1,
       "service_name": "playground_enterprise_otel",
-      "trace_sample_rate": 0.5
+      "trace_sample_rate": 1
     },
     "telemetry/opentelemetry-security": {
       "otlp": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - "./config/telemetry-dashboards/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.6.0
     domainname: tempo
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
@@ -134,7 +134,7 @@ services:
     ports:
       - "4243:4243"
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: quay.io/keycloak/keycloak:26.2
     ports:
       - "8085:8080"
     volumes:


### PR DESCRIPTION
Valik Solorzano (Zebra) sent over this fixes. The tracing one turned out to be a real regression on our side (nice catch!).

Jaeger tracing had quietly broken back in April. Commit 198cb4b recompiled the Flexible Config from a template that still had an old Jaeger bug, undoing a 2024 fix that had only ever been applied to the compiled krakend.json (never the template). It reverted three things at once: the jaeger host (back to the `jaeeger` typo), the debug_jaeger exporter (traces disabled), and trace_sample_rate (1 → 0.5). First commit restores all three, this time in the template too, so a recompile won't wipe it again.

Second commit pins two images Valik hit on startup: tempo (latest had drifted to 3.x and broke its config) → 2.6.0, and keycloak (26.0 crashes on Apple Silicon) → 26.2.

Thanks Valik!
